### PR TITLE
bugfix: fail if yard documentation is invalid

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ task :rubocop do
 end
 
 task :yard do
-  sh 'yard'
+  sh "bundle exec yardoc --fail-on-warning 'lib/**/*.rb'"
 end
 
 task default: %i[spec rubocop yard]

--- a/lib/libmpsse/mpsse.rb
+++ b/lib/libmpsse/mpsse.rb
@@ -64,7 +64,7 @@ module LibMpsse
     # Performs a bit-wise read of up to 8 bits.
     #
     # @param size [Integer] number of bits to read
-    # @retrun an 8-bit byte containing the read bits
+    # @return an 8-bit byte containing the read bits
     def read_bits(size = 8)
       LibMpsse::ReadBits(context, size)
     end


### PR DESCRIPTION
* s/@retrun/@return/